### PR TITLE
fix/ Maintain shared book info data regarding the shelf info for search and main pages

### DIFF
--- a/starter/src/App.js
+++ b/starter/src/App.js
@@ -48,6 +48,7 @@ function App() {
           <Route
             path="/search"
             element={<SearchPage
+              books={books}
               onChangeBookshelf={(book, shelf) => handleChangeBookshelf(book, shelf)} />} />
           <Route
             exact path="/"

--- a/starter/src/components/bookshelf-changer/index.js
+++ b/starter/src/components/bookshelf-changer/index.js
@@ -9,7 +9,7 @@ function BookshelfChanger({ book, currentShelf, onChangeBookshelf }) {
                 onChange={(e) => {
                     onChangeBookshelf(book, e.target.value)
                 }}>
-                <option value="none" disabled>
+                <option value="" disabled>
                     Move to...
                 </option>
                 <option value="currentlyReading">

--- a/starter/src/pages/search-page.js
+++ b/starter/src/pages/search-page.js
@@ -6,7 +6,7 @@ import BookshelfBooks from '../components/bookshelf-books';
 import ExportExcel from '../components/export-excel';
 import PropTypes from 'prop-types';
 
-function SearchPage({ onChangeBookshelf }) {
+function SearchPage({ books, onChangeBookshelf }) {
     const [query, setQuery] = useState("");
     const [searchReasult, setSearchReasult] = useState([]);
 
@@ -14,13 +14,29 @@ function SearchPage({ onChangeBookshelf }) {
         setQuery(query);
         const searchBooks = async () => {
             await BooksAPI.search(query.toLowerCase())
-                .then((response) => {
-                    if (response.error) {
+                .then((searchReasultResponse) => {
+                    if (searchReasultResponse.error) {
                         handleClearSearchResults();
                         NotificationManager.info(`No books found try searching with different query to get what you are looking for`);
                         return;
                     }
-                    setSearchReasult(response)
+                    // NOTE: the response from the search API doesn't include the shelf info
+                    //  & it is required to keep the same experience on the main page 
+                    // to reflect the info of the shelf if the book is currently on one of the shelves
+
+                    // Get the matched books in the main array passed through props called books 
+                    // & the array that I got from the search API's response
+                    let matchedBooks = books?.filter(book => searchReasultResponse?.some(searchReasult => book.id === searchReasult.id));
+
+                    // remove the matched books from search API's array as it contains old data
+                    let finalSearchReasult = searchReasultResponse.filter(searchReasult => !matchedBooks.some(matchedBook => searchReasult.id === matchedBook.id))
+
+                    // assign shelf value as "none" if the book doesn't exist in the original books (that I got through props)
+                    finalSearchReasult.map((book) => book.shelf = "none")
+
+                    // Concat the matched books data that holds the shelf info (that I got earlier from the books array) 
+                    // to the final Search Result that got filtered out & update the state accordingly
+                    setSearchReasult(matchedBooks.concat(finalSearchReasult))
                 }).catch(() => {
                     handleClearSearchResults();
                     return;
@@ -67,6 +83,7 @@ function SearchPage({ onChangeBookshelf }) {
 
 // Add component props type checking
 SearchPage.propTypes = {
+    books: PropTypes.array.isRequired,
     onChangeBookshelf: PropTypes.func.isRequired,
 }
 


### PR DESCRIPTION
- If a book is assigned to a shelf on the main page and that book also appears on the search page, the correct shelf should be selected for that book on the search page.

- If that book's shelf is changed on the search page, that change should be reflected on the main page as well.

- The option "None" should be selected if a book has not been assigned to a shelf.

- Books have the same state on both the search page and the main page:
    - If a book is on a bookshelf, that is reflected in both locations with the same shelf selected.